### PR TITLE
05.6.1. CourseStaff Model Update

### DIFF
--- a/App/models/courseStaff.py
+++ b/App/models/courseStaff.py
@@ -1,34 +1,61 @@
 from App.database import db
-from .staff import Staff
 
 class CourseStaff(db.Model):
     __tablename__ = 'courseStaff'
 
     # Attributes
     courseStaffID = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    courseCode = db.Column(db.String(9), db.ForeignKey('course.courseCode'), nullable=False)
+    courseOfferingID = db.Column(db.Integer, db.ForeignKey('course_offering.offeringID'), nullable=False)
     staffID = db.Column(db.Integer, db.ForeignKey('staff.staffID'), nullable=False)
 
     # Relationships
-    course = db.relationship('Course', backref='course_staff')
+    course_offering = db.relationship('CourseOffering', backref='course_staff')
     staff = db.relationship('Staff', backref='assigned_courses')
 
-    def __init__(self, courseCode, staffID):
-        self.courseCode = courseCode
+    def __init__(self, courseOfferingID, staffID):
+        self.courseOfferingID = courseOfferingID
         self.staffID = staffID
 
     def get_json(self):
         return {
-            "courseCode": self.courseCode,
-            "staffID": self.staffID,
-            "staffEmail": self.staff.email if self.staff else None
+            "courseStaffID": self.courseStaffID,
+            "courseOffering": {
+                "courseCode": self.course_offering.courseCode if self.course_offering else None,
+                "courseName": self.course_offering.course.courseName if self.course_offering and self.course_offering.course else None,
+                "semester": self.course_offering.semester.semesterName if self.course_offering and self.course_offering.semester else None,
+                "academicYear": self.course_offering.semester.academicYear if self.course_offering and self.course_offering.semester else None,
+                "startDate": self.course_offering.semester.startDate if self.course_offering and self.course_offering.semester else None,
+                "endDate": self.course_offering.semester.endDate if self.course_offering and self.course_offering.semester else None,
+            },
+            "staff": {
+                "staffID": self.staffID,
+                "staffName": f"{self.staff.firstName} {self.staff.lastName}" if self.staff else None,
+                "staffEmail": self.staff.email if self.staff else None,
+            },
         }
 
     def __str__(self):
-        return f"CourseStaff(courseCode='{self.courseCode}', staffID='{self.staffID}', staffEmail='{self.staff.email if self.staff else 'No email'}')"
+        course_details = (
+            f"courseCode='{self.course_offering.courseCode}', "
+            f"courseName='{self.course_offering.course.courseName if self.course_offering and self.course_offering.course else 'No course name'}', "
+            f"semester='{self.course_offering.semester.semesterName if self.course_offering and self.course_offering.semester else 'No semester'}', "
+            f"academicYear='{self.course_offering.semester.academicYear if self.course_offering and self.course_offering.semester else 'No year'}'"
+        )
+        staff_details = (
+            f"staffID='{self.staffID}', "
+            f"staffName='{self.staff.firstName} {self.staff.lastName}' if self.staff else 'No name', "
+            f"staffEmail='{self.staff.email if self.staff else 'No email'}'"
+        )
+        return f"CourseStaff({course_details}, {staff_details})"
 
     def __repr__(self):
         return (
-            f"CourseStaff(courseStaffID={self.courseStaffID}, courseCode='{self.courseCode}', "
-            f"staffID={self.staffID}, staffEmail='{self.staff.email if self.staff else 'No email'}')"
+            f"CourseStaff(courseStaffID={self.courseStaffID}, "
+            f"courseCode='{self.course_offering.courseCode if self.course_offering else 'No course code'}', "
+            f"courseName='{self.course_offering.course.courseName if self.course_offering and self.course_offering.course else 'No course name'}', "
+            f"semester='{self.course_offering.semester.semesterName if self.course_offering and self.course_offering.semester else 'No semester'}', "
+            f"academicYear='{self.course_offering.semester.academicYear if self.course_offering and self.course_offering.semester else 'No year'}', "
+            f"staffID={self.staffID}, "
+            f"staffName='{self.staff.firstName} {self.staff.lastName}' if self.staff else 'No name', "
+            f"staffEmail='{self.staff.email if self.staff else 'No email'}')"
         )


### PR DESCRIPTION
Modified the CourseStaff Model, replacing the relationship it had with course to courseOffering instead, the reason for this was to be more accurate with the timeline the specific course is available, rather than connecting a staff to a basic course object with no sense of timestamp whatsoever, the better fit is for it to be connection to CourseOffering, which date and academic year is a consideration properly tying a staff to a specific courseOffering, rather than a general course.

This helps in situations where if a Staff was assigned to a course in 2002, and then assigned again in 2004, their would be a way to differentiate between those two courses that were offered at different years